### PR TITLE
Relax poison dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Raygun.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:poison, "~> 1.4.0"},
+      {:poison, "~> 1.4"},
       {:httpoison, "~> 0.7.2"},
       {:timex, "~> 0.19.4"},
       {:plug, "~> 1.0.0"},


### PR DESCRIPTION
Now that 1.5 is out, this relaxes requirements. Following semver, 1.x should work (in theory)