### PR TITLE
Fixing issue when message_payload receives a charlist

### DIFF
--- a/lib/raygun/format.ex
+++ b/lib/raygun/format.ex
@@ -11,6 +11,10 @@ defmodule Raygun.Format do
   @doc """
   Builds an error payload that Raygun will understand for a string.
   """
+  def message_payload(msg, opts) when is_list(msg) do
+    msg_as_string = List.to_string(msg)
+    message_payload(msg_as_string, opts)
+  end
   def message_payload(msg, opts) do
     %{
       occurredOn: now,


### PR DESCRIPTION
Fixes #17 and probably #14.
As far as I can see, this could happen when Logger reports an non-exception, and I have seen regularly it when a `GenServer` crashes. `msg` in ` def handle_event({:error, gl, {Logger, msg, _ts, _md}}, state) when node(gl) == node()` could be a list like:
```elixir
iex(1)> l = [["GenServer", [10 | " *foo"]]]
[["GenServer", [10 | " *foo"]]]
iex(2)> List.to_string(l)
"GenServer\n *foo"
``` 